### PR TITLE
Show error if duplicate names

### DIFF
--- a/src/components/PronDict/NewForm.js
+++ b/src/components/PronDict/NewForm.js
@@ -16,7 +16,7 @@ class NewForm extends Component {
     }
 
     render() {
-        const { t, currentDataset, datasets, pronDictNew } = this.props;
+        const { t, error, currentDataset, datasets, pronDictNew } = this.props;
 
         let defaultDatasetName = ''
         if (currentDataset) {
@@ -46,8 +46,7 @@ class NewForm extends Component {
                 }}
                 onSubmit={(values, { setSubmitting }) => {
                     const postData = { name: values.name, dataset_name: values.dataset_name }
-                    pronDictNew(postData)
-                    this.props.history.push(urls.gui.pronDict.l2s)
+                    pronDictNew(postData, this.props.history)
                 }}
             >
                 {({
@@ -77,9 +76,9 @@ class NewForm extends Component {
                                     }
                                 </Field>
                             </Form.Field>
-
-                            <Divider />
-
+                            {error &&
+                                <p className={"error-message"}>{error}</p>
+                            }
                             <Button type="button" onClick={handleSubmit}>
                                 {t('common.addNewButton')}
                             </Button>
@@ -94,15 +93,29 @@ const mapStateToProps = state => {
     return {
         name: state.pronDict.name,
         currentDataset: state.dataset.name,
-        datasets: state.dataset.datasetList
+        datasets: state.dataset.datasetList,
+        error: state.pronDict.error
     }
 }
 const mapDispatchToProps = dispatch => ({
     datasetList: () => {
         dispatch(datasetList())
     },
-    pronDictNew: postData => {
+    pronDictNew: (postData, history) => {
         dispatch(pronDictNew(postData))
+            .then(response => {
+                console.log('pron dict response', response)
+                if (response.status===500) {
+                    console.log('response.status', response.status)
+                    throw Error(response.error)
+                }
+                return response
+            })
+            .then(response => {
+                history.push(urls.gui.pronDict.l2s)
+            })
+            .catch(error => console.log("error", error))
     }
 })
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(translate('common')(NewForm)));
+

--- a/src/redux/reducers/modelReducer.js
+++ b/src/redux/reducers/modelReducer.js
@@ -16,8 +16,18 @@ const model = (state = initState, action) => {
     switch (action.type) {
 
         case actionTypes.MODEL_NEW_SUCCESS:
-            var { config, results } = action.response.data.data
-            return { ...initState, name: config.name }
+            if (action.response.data.status==500){
+                return { ...initState,
+                    status: action.response.data.status,
+                    error: action.response.data.error
+                }
+            } else {
+                var {name} = action.response.data.data.config
+                return {
+                    ...initState,
+                    name
+                }
+            }
 
         case actionTypes.MODEL_LOAD_SUCCESS:
             var { config } = action.response.data.data
@@ -26,7 +36,6 @@ const model = (state = initState, action) => {
                 name: config.name,
                 datasetName: config.dataset_name,
                 pronDictName: config.pron_dict_name,
-                results,
                 settings: {...state.settings, ngram: config.ngram},
                 status: 'ready'
             }
@@ -58,7 +67,7 @@ const model = (state = initState, action) => {
         case actionTypes.MODEL_RESULTS_SUCCESS:
             var { data, status } = action.response.data
             if (status == 200) {
-                return { ...state, results:data.results }
+                return { ...state, results: data.results }
             } else {
                 console.log(data)
                 return { ...state }

--- a/src/redux/reducers/pronDictReducer.js
+++ b/src/redux/reducers/pronDictReducer.js
@@ -17,10 +17,17 @@ const pronDict = (state = initState, action) => {
     switch (action.type) {
 
         case actionTypes.PRON_DICT_NEW_SUCCESS:
-            var { name } = action.response.data.data.config
-            return {
-                ...initState,
-                name
+            if (action.response.data.status==500){
+                return { ...initState,
+                    status: action.response.data.status,
+                    error: action.response.data.error
+                }
+            } else {
+                var {name} = action.response.data.data.config
+                return {
+                    ...initState,
+                    name
+                }
             }
 
         case actionTypes.PRON_DICT_LOAD_SUCCESS:


### PR DESCRIPTION
This PR shows API error code of duplicate name for dataset, pron dict and model. Receives the error message based on a status code and show the 'human_message' on the page. History.push stuff is moved into .then success thing so navigation doesn't happen when the error is caught.

Goes with https://github.com/CoEDL/elpis/pull/101