### PR TITLE
only offer trained models for transcription

### DIFF
--- a/src/components/Transcription/New.js
+++ b/src/components/Transcription/New.js
@@ -76,11 +76,16 @@ class NewTranscription extends Component {
     render = () => {
         const { t, filename, list, status, text, modelName } = this.props;
 
-        const listOptions = list.map(model => ({"key": model.name, "value": model.name, "text": model.name}))
+        //Only show trained models
+        const listTrained = list.filter(model => model.status === 'trained')
+        const listOptions = listTrained.map(model => ({
+            "key": model.name,
+            "value": model.name,
+            "text": model.name
+        }))
 
-        // preven the buttnos from being clicked if we haven't got
-        // an active model, or file to transcribe
-        let enableButtons = (modelName && filename &&
+        // prevent the buttons from being clicked if we haven't got an active model, or file to transcribe
+        let enableTranscription = (modelName && filename &&
             (status == 'ready' || status == 'transcribed' )) ? true : false
 
         const loadingIcon = (status == 'transcribing') ? (
@@ -145,7 +150,7 @@ class NewTranscription extends Component {
                             }
 
                             <Segment>
-                                <Button onClick={this.handleTranscribe} disabled={!enableButtons} >
+                                <Button onClick={this.handleTranscribe} disabled={!enableTranscription} >
                                     {t('transcription.new.transcribe')}
                                 </Button>
                             </Segment>


### PR DESCRIPTION
If user selected a model that had been created but not trained, then uploaded an audio file, there would be a backend error but no indication of failure in the gui, eg 
```
FileNotFoundError: [Errno 2] No such file or directory: '/state/models/647d0e3914ecc39fe1686c7b60b63733/kaldi/data/test/spk2utt'
```
This avoids the error by not offering untrained models in the list of models on the new transcription page. 

