### PR TITLE
Unified tier type/order/name dropdowns into a single cascading dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elpis-gui",
-  "version": "0.94.1",
+  "version": "0.94.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -115,6 +115,7 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                             dataEntryElement = (<Select
                                 // value={settings[ui_name]}
                                 options={options}
+                                // default value is first option
                                 defaultValue={options[0].value}
                                 onChange={(event, data) => {
                                     let newSettings = {...settings};
@@ -128,9 +129,12 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                                     if (ui_name === "selection_mechanism") {
                                         // Hide other selection mechanisms and show current one
                                         for (const option of data.options) {
+                                            newSettings[option.value] = null;
                                             ui['data'][option.value]['shown'] = false;
                                         }
                                         ui['data'][data.value]['shown'] = true;
+                                        // Update new settings with default value of selected mechanism
+                                        newSettings[data.value] = ui['data'][data.value]['options'][0]
                                     }
                                     changeSettingsCallback(newSettings)
                                 }}

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -95,12 +95,18 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                             data.options.forEach(v => {
                                 options.push({key: v, value: v, text: v})
                             });
+                            if (ui_name === "selection_mechanism") {
+                                settings[options[0].value] = ui['data'][options[0].value]['options'][0];
+                            }
                             dataEntryElement = (<Select
-                                // value={settings[ui_name]}
+                                value={ui_name === "selection_mechanism" 
+                                    ? options[0].value
+                                    : settings[ui_name]}
                                 options={options}
                                 // default value is first option
-                                defaultValue={options[0].value}
+                                // defaultValue={options[0].value}
                                 onChange={(event, data) => {
+                                    console.log(settings[ui_name])
                                     let newSettings = {...settings};
                                     // Convert from "not selected" string back to null.
                                     if (data.value === "- not selected -") {

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -99,9 +99,10 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                                 settings[options[0].value] = ui['data'][options[0].value]['options'][0];
                             }
                             dataEntryElement = (<Select
-                                value={ui_name === "selection_mechanism" 
-                                    ? options[0].value
-                                    : settings[ui_name]}
+                                value={settings[ui_name]}
+                                // value={ui_name === "selection_mechanism" 
+                                //     ? options[0].value
+                                //     : settings[ui_name]}
                                 options={options}
                                 // default value is first option
                                 // defaultValue={options[0].value}

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -17,10 +17,22 @@ function groupSettingsFromUI(ui) {
     return settingGroups;
 }
 
+
 const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
     // console.group("GeneratedUI");
     // console.log({settings});
     // console.log({ui});
+
+    const forceUpdate = React.useState()[1].bind(null, {})  // see NOTE above
+
+    // On initialisation of component, show the tier name and set it properly
+    useEffect(() => {
+        if (settings !== null) {
+            ui['data']['tier_name']['shown'] = true;
+            settings['tier_name'] = ui['data']['tier_name']['options'][0]
+            changeSettingsCallback(settings)
+        }
+    }, [ui])
 
     if (ui === null || ui === undefined) {
         // console.groupEnd();
@@ -35,22 +47,14 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
     }
 
     const handleSelectChange = (ui_name, data) => {
-        console.log(settings)
+        console.log("test")
+        // console.log(settings)
         let newSettings = {...settings};
-        // Convert from "not selected" string back to null.
-        // if (data.value === "- not selected -") {
-        //     newSettings[ui_name] = null;
-        // } else {
-        //     newSettings[ui_name] = data.value;
-        // }
-        // Special dropdown logic for selection mechanism
         if (ui_name === "selection_mechanism") {
             // Hide other selection mechanisms and show current one
             for (const option of data.options) {
-                if (option.value !== '-- none selected --') {
-                    newSettings[option.value] = null;
-                    ui['data'][option.value]['shown'] = false;
-                }
+                newSettings[option.value] = null;
+                ui['data'][option.value]['shown'] = false;
             }
             ui['data'][data.value]['shown'] = true;
             // Update new settings with default value of selected mechanism

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -100,12 +100,7 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                             }
                             dataEntryElement = (<Select
                                 value={settings[ui_name]}
-                                // value={ui_name === "selection_mechanism" 
-                                //     ? options[0].value
-                                //     : settings[ui_name]}
                                 options={options}
-                                // default value is first option
-                                // defaultValue={options[0].value}
                                 onChange={(event, data) => {
                                     console.log(settings[ui_name])
                                     let newSettings = {...settings};

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -62,84 +62,94 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
             } else { // ui['type'][ui_name] == "settings"
                 // console.log("Building input");
                 let data = ui['data'][ui_name];
-                let label = (data.display_name !== null) ? data.display_name : ui_name;
+                if (data.shown) {
+                    let label = (data.display_name !== null) ? data.display_name : ui_name;
 
-                // Switch input type based on ui specification
-                let dataEntryElement;
-                switch (data.ui_format) {
-                    case 'text': {
-                        dataEntryElement = (<Input
-                                type='text'
-                                value={settings[ui_name]}
-                                onChange={(event, data) => {
-                                    handleStrChange(ui_name, data)
-                                }} />);
-                        }
-                        break;
-                    case 'textarea': {
-                        dataEntryElement = (<TextArea
-                                value={settings[ui_name]}
-                                onChange={(event, data) => {
-                                    handleStrChange(ui_name, data)
-                                }} />);
-                        }
-                        break;
-                    case 'int': {
-                        dataEntryElement = (<Input type='number'/>); /* TODO */
-                        }
-                        break;
-                    case 'select': {
-                        let options = [];
-                        // Build options
-                        data.options.forEach(v => {
-                            // <Select> does not like to display text if the key or value (?) is null.
-                            // So convert null to string "- not selected -".
-                            if (v === null || v === '') {
-                                // console.log("pushing: ", {
-                                //     key: "- not selected -",
-                                //     value: "- not selected -",
-                                //     text: "- not selected -"
-                                // });
-                                options.push({
-                                    key: "- not selected -",
-                                    value: "- not selected -",
-                                    text: "- not selected -"
-                                })
-                            } else {
-                                // console.log("pushing: ", {key: v, value: v, text: v});
-                                options.push({key: v, value: v, text: v})
+                    // Switch input type based on ui specification
+                    let dataEntryElement;
+                    switch (data.ui_format) {
+                        case 'text': {
+                            dataEntryElement = (<Input
+                                    type='text'
+                                    value={settings[ui_name]}
+                                    onChange={(event, data) => {
+                                        handleStrChange(ui_name, data)
+                                    }} />);
                             }
-                        });
-                        dataEntryElement = (<Select
-                            value={settings[ui_name]}
-                            options={options}
-                            onChange={(event, data) => {
-                                let newSettings = {...settings};
-                                // Convert from "not selected" string back to null.
-                                if (data.value === "- not selected -") {
-                                    newSettings[ui_name] = null;
+                            break;
+                        case 'textarea': {
+                            dataEntryElement = (<TextArea
+                                    value={settings[ui_name]}
+                                    onChange={(event, data) => {
+                                        handleStrChange(ui_name, data)
+                                    }} />);
+                            }
+                            break;
+                        case 'int': {
+                            dataEntryElement = (<Input type='number'/>); /* TODO */
+                            }
+                            break;
+                        case 'select': {
+                            let options = [];
+                            // Build options
+                            data.options.forEach(v => {
+                                // <Select> does not like to display text if the key or value (?) is null.
+                                // So convert null to string "- not selected -".
+                                if (v === null || v === '') {
+                                    // console.log("pushing: ", {
+                                    //     key: "- not selected -",
+                                    //     value: "- not selected -",
+                                    //     text: "- not selected -"
+                                    // });
+                                    options.push({
+                                        key: "- not selected -",
+                                        value: "- not selected -",
+                                        text: "- not selected -"
+                                    })
                                 } else {
-                                    newSettings[ui_name] = data.value;
+                                    // console.log("pushing: ", {key: v, value: v, text: v});
+                                    options.push({key: v, value: v, text: v})
                                 }
-                                changeSettingsCallback(newSettings)
-                            }}
-                            selection
-                        />);
-                        // TODO: add a onChange that dispatches the setting (do this for int and string as well)
+                            });
+                            dataEntryElement = (<Select
+                                value={settings[ui_name]}
+                                options={options}
+                                onChange={(event, data) => {
+                                    let newSettings = {...settings};
+                                    // Convert from "not selected" string back to null.
+                                    if (data.value === "- not selected -") {
+                                        newSettings[ui_name] = null;
+                                    } else {
+                                        newSettings[ui_name] = data.value;
+                                    }
+                                    // Special dropdown logic for selection mechanism
+                                    if (ui_name === "selection_mechanism") {
+                                        // Hide other selection mechanisms and show selected one
+                                        for (const option of data.options) {
+                                            ui['data'][option.value]['shown'] = false;
+                                        }
+                                        ui['data'][data.value]['shown'] = true;
+                                    }
+                                    changeSettingsCallback(newSettings)
+                                }}
+                                selection
+                            />);
+                            // TODO: add a onChange that dispatches the setting (do this for int and string as well)
+                            }
+                            break;
+                        default: {
                         }
-                        break;
-                    default: {
                     }
-                }
 
-                // Construct row for individual setting
-                let row = (
-                    <Table.Row key={ui_name}>
-                        <Table.Cell collapsing>{label}</Table.Cell>
-                        <Table.Cell>{dataEntryElement}</Table.Cell>
-                    </Table.Row>
-                );
-                settingRows.push(row);
+                    // Construct row for individual setting
+                    let row = (
+                        <Table.Row key={ui_name}>
+                            <Table.Cell collapsing>{label}</Table.Cell>
+                            <Table.Cell>{dataEntryElement}</Table.Cell>
+                        </Table.Row>
+                    );
+                    settingRows.push(row);
+                }
             }
             // console.groupEnd();
         });

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Select, Form, Input, Table, TextArea } from 'semantic-ui-react';
 
 function groupSettingsFromUI(ui) {
@@ -34,6 +34,31 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
         changeSettingsCallback(newSettings)
     }
 
+    const handleSelectChange = (ui_name, data) => {
+        console.log(settings)
+        let newSettings = {...settings};
+        // Convert from "not selected" string back to null.
+        // if (data.value === "- not selected -") {
+        //     newSettings[ui_name] = null;
+        // } else {
+        //     newSettings[ui_name] = data.value;
+        // }
+        // Special dropdown logic for selection mechanism
+        if (ui_name === "selection_mechanism") {
+            // Hide other selection mechanisms and show current one
+            for (const option of data.options) {
+                if (option.value !== '-- none selected --') {
+                    newSettings[option.value] = null;
+                    ui['data'][option.value]['shown'] = false;
+                }
+            }
+            ui['data'][data.value]['shown'] = true;
+            // Update new settings with default value of selected mechanism
+            newSettings[data.value] = ui['data'][data.value]['options'][0]
+        }
+        changeSettingsCallback(newSettings)
+    }
+    
     // Sort names into groups by title followed by settings.
     let settingGroups = groupSettingsFromUI(ui);
 
@@ -64,7 +89,6 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                 let data = ui['data'][ui_name];
                 if (data.shown) {
                     let label = (data.display_name !== null) ? data.display_name : ui_name;
-
                     // Switch input type based on ui specification
                     let dataEntryElement;
                     switch (data.ui_format) {
@@ -95,33 +119,11 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                             data.options.forEach(v => {
                                 options.push({key: v, value: v, text: v})
                             });
-                            if (ui_name === "selection_mechanism") {
-                                settings[options[0].value] = ui['data'][options[0].value]['options'][0];
-                            }
                             dataEntryElement = (<Select
-                                value={settings[ui_name]}
+                                defaultValue={settings[ui_name]}
                                 options={options}
                                 onChange={(event, data) => {
-                                    console.log(settings[ui_name])
-                                    let newSettings = {...settings};
-                                    // Convert from "not selected" string back to null.
-                                    if (data.value === "- not selected -") {
-                                        newSettings[ui_name] = null;
-                                    } else {
-                                        newSettings[ui_name] = data.value;
-                                    }
-                                    // Special dropdown logic for selection mechanism
-                                    if (ui_name === "selection_mechanism") {
-                                        // Hide other selection mechanisms and show current one
-                                        for (const option of data.options) {
-                                            newSettings[option.value] = null;
-                                            ui['data'][option.value]['shown'] = false;
-                                        }
-                                        ui['data'][data.value]['shown'] = true;
-                                        // Update new settings with default value of selected mechanism
-                                        newSettings[data.value] = ui['data'][data.value]['options'][0]
-                                    }
-                                    changeSettingsCallback(newSettings)
+                                    handleSelectChange(ui_name, data)
                                 }}
                                 selection
                             />);

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -101,19 +101,21 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                                     //     value: "- not selected -",
                                     //     text: "- not selected -"
                                     // });
-                                    options.push({
-                                        key: "- not selected -",
-                                        value: "- not selected -",
-                                        text: "- not selected -"
-                                    })
+                                    // This shouldn't be needed?
+                                    // options.push({
+                                    //     key: "- not selected -",
+                                    //     value: "- not selected -",
+                                    //     text: "- not selected -"
+                                    // })
                                 } else {
                                     // console.log("pushing: ", {key: v, value: v, text: v});
                                     options.push({key: v, value: v, text: v})
                                 }
                             });
                             dataEntryElement = (<Select
-                                value={settings[ui_name]}
+                                // value={settings[ui_name]}
                                 options={options}
+                                defaultValue={options[0].value}
                                 onChange={(event, data) => {
                                     let newSettings = {...settings};
                                     // Convert from "not selected" string back to null.
@@ -124,7 +126,7 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                                     }
                                     // Special dropdown logic for selection mechanism
                                     if (ui_name === "selection_mechanism") {
-                                        // Hide other selection mechanisms and show selected one
+                                        // Hide other selection mechanisms and show current one
                                         for (const option of data.options) {
                                             ui['data'][option.value]['shown'] = false;
                                         }

--- a/src/components/Dataset/GeneratedUI.js
+++ b/src/components/Dataset/GeneratedUI.js
@@ -93,24 +93,7 @@ const GeneratedUI = ({settings, ui, changeSettingsCallback}) => {
                             let options = [];
                             // Build options
                             data.options.forEach(v => {
-                                // <Select> does not like to display text if the key or value (?) is null.
-                                // So convert null to string "- not selected -".
-                                if (v === null || v === '') {
-                                    // console.log("pushing: ", {
-                                    //     key: "- not selected -",
-                                    //     value: "- not selected -",
-                                    //     text: "- not selected -"
-                                    // });
-                                    // This shouldn't be needed?
-                                    // options.push({
-                                    //     key: "- not selected -",
-                                    //     value: "- not selected -",
-                                    //     text: "- not selected -"
-                                    // })
-                                } else {
-                                    // console.log("pushing: ", {key: v, value: v, text: v});
-                                    options.push({key: v, value: v, text: v})
-                                }
+                                options.push({key: v, value: v, text: v})
                             });
                             dataEntryElement = (<Select
                                 // value={settings[ui_name]}


### PR DESCRIPTION
This PR also requires the corresponding PR in `elpis` to be merged.

This reconfigures the dropdowns for Import Settings/Tiers so that instead of having three dropdowns (of which only one is meant to be selected), there is a single dropdown for "Selection Mechanism" (Tier Type/Tier Name/Tier Order) which then cascades into a second dropdown based on the first.

To facilitate this a `shown` parameter was added to the setting-related methods in `elpis/transformer/__init__.py` which specifies whether a given row of the settings should be shown by default. Currently Tier Type is set to `shown=True` and Tier Name and Tier Order are set to `shown=False`.

![image](https://user-images.githubusercontent.com/36957422/91106370-d1b52480-e6b5-11ea-984a-5d51d45129c3.png)
